### PR TITLE
Convert explain result `nil` to `'NULL'`

### DIFF
--- a/lib/mysql2_query_filter/plugin/casual_log.rb
+++ b/lib/mysql2_query_filter/plugin/casual_log.rb
@@ -57,7 +57,7 @@ module Mysql2QueryFilter::Plugin
       badquery = false
 
       REGEXPS.each do |key, regexp|
-        value = explain[key] || ''
+        value = explain[key] ||= 'NULL'
 
         value.gsub!(regexp) do |m|
           badquery = true


### PR DESCRIPTION
Otherwise, it does not match the REGEXP of `possible_keys` and `key`.
